### PR TITLE
Feature/22: 承認機能データモデル基盤構築

### DIFF
--- a/app/models/attendance_change_request.rb
+++ b/app/models/attendance_change_request.rb
@@ -1,0 +1,11 @@
+class AttendanceChangeRequest < ApplicationRecord
+  belongs_to :attendance
+  belongs_to :requester, class_name: 'User'
+  belongs_to :approver, class_name: 'User'
+
+  validates :attendance, :requester, :approver, presence: true
+  validates :original_started_at, :original_finished_at, presence: true
+  validates :requested_started_at, :requested_finished_at, presence: true
+
+  enum status: { pending: 0, approved: 1, rejected: 2 }
+end

--- a/app/models/monthly_approval.rb
+++ b/app/models/monthly_approval.rb
@@ -1,0 +1,13 @@
+class MonthlyApproval < ApplicationRecord
+  belongs_to :user
+  belongs_to :approver, class_name: 'User'
+
+  validates :user, :approver, :target_month, presence: true
+  validates :target_month, uniqueness: { scope: :user_id }
+
+  enum status: { pending: 0, approved: 1, rejected: 2 }
+
+  def approve!
+    update!(status: :approved, approved_at: Time.current)
+  end
+end

--- a/app/models/overtime_request.rb
+++ b/app/models/overtime_request.rb
@@ -1,0 +1,9 @@
+class OvertimeRequest < ApplicationRecord
+  belongs_to :user
+  belongs_to :approver, class_name: 'User'
+
+  validates :user, :approver, :worked_on, presence: true
+  validates :estimated_end_time, :business_content, presence: true
+
+  enum status: { pending: 0, approved: 1, rejected: 2 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,10 @@ class User < ApplicationRecord
   has_many :attendances, dependent: :destroy
   has_secure_password validations: false
 
+  # 組織階層
+  belongs_to :manager, class_name: 'User', optional: true
+  has_many :subordinates, class_name: 'User', foreign_key: :manager_id
+
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
@@ -46,5 +50,10 @@ class User < ApplicationRecord
   # ユーザーのログイン情報を破棄する
   def forget
     update_attribute(:remember_digest, nil)
+  end
+
+  # 部下がいるかどうかを判定
+  def manager?
+    subordinates.exists?
   end
 end

--- a/db/migrate/20251003073319_add_manager_id_to_users.rb
+++ b/db/migrate/20251003073319_add_manager_id_to_users.rb
@@ -1,0 +1,7 @@
+class AddManagerIdToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :manager_id, :bigint
+    add_index :users, :manager_id
+    add_foreign_key :users, :users, column: :manager_id
+  end
+end

--- a/db/migrate/20251003073413_create_monthly_approvals.rb
+++ b/db/migrate/20251003073413_create_monthly_approvals.rb
@@ -1,0 +1,14 @@
+class CreateMonthlyApprovals < ActiveRecord::Migration[7.1]
+  def change
+    create_table :monthly_approvals do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :approver, null: false, foreign_key: { to_table: :users }
+      t.date :target_month, null: false
+      t.integer :status, default: 0, null: false
+      t.datetime :approved_at
+
+      t.timestamps
+    end
+    add_index :monthly_approvals, [:user_id, :target_month], unique: true
+  end
+end

--- a/db/migrate/20251003073443_create_attendance_change_requests.rb
+++ b/db/migrate/20251003073443_create_attendance_change_requests.rb
@@ -1,0 +1,16 @@
+class CreateAttendanceChangeRequests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :attendance_change_requests do |t|
+      t.references :attendance, null: false, foreign_key: true
+      t.references :requester, null: false, foreign_key: { to_table: :users }
+      t.references :approver, null: false, foreign_key: { to_table: :users }
+      t.datetime :original_started_at, null: false
+      t.datetime :original_finished_at, null: false
+      t.datetime :requested_started_at, null: false
+      t.datetime :requested_finished_at, null: false
+      t.integer :status, default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251003073452_create_overtime_requests.rb
+++ b/db/migrate/20251003073452_create_overtime_requests.rb
@@ -1,0 +1,15 @@
+class CreateOvertimeRequests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :overtime_requests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :approver, null: false, foreign_key: { to_table: :users }
+      t.date :worked_on, null: false
+      t.datetime :estimated_end_time, null: false
+      t.text :business_content, null: false
+      t.boolean :next_day_flag, default: false
+      t.integer :status, default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_28_135144) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_03_073452) do
+  create_table "attendance_change_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "attendance_id", null: false
+    t.bigint "requester_id", null: false
+    t.bigint "approver_id", null: false
+    t.datetime "original_started_at", null: false
+    t.datetime "original_finished_at", null: false
+    t.datetime "requested_started_at", null: false
+    t.datetime "requested_finished_at", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["approver_id"], name: "index_attendance_change_requests_on_approver_id"
+    t.index ["attendance_id"], name: "index_attendance_change_requests_on_attendance_id"
+    t.index ["requester_id"], name: "index_attendance_change_requests_on_requester_id"
+  end
+
   create_table "attendances", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "worked_on", null: false
     t.datetime "started_at"
@@ -21,6 +37,33 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_28_135144) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "worked_on"], name: "index_attendances_on_user_id_and_worked_on", unique: true
     t.index ["user_id"], name: "index_attendances_on_user_id"
+  end
+
+  create_table "monthly_approvals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "approver_id", null: false
+    t.date "target_month", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "approved_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["approver_id"], name: "index_monthly_approvals_on_approver_id"
+    t.index ["user_id", "target_month"], name: "index_monthly_approvals_on_user_id_and_target_month", unique: true
+    t.index ["user_id"], name: "index_monthly_approvals_on_user_id"
+  end
+
+  create_table "overtime_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "approver_id", null: false
+    t.date "worked_on", null: false
+    t.datetime "estimated_end_time", null: false
+    t.text "business_content", null: false
+    t.boolean "next_day_flag", default: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["approver_id"], name: "index_overtime_requests_on_approver_id"
+    t.index ["user_id"], name: "index_overtime_requests_on_user_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -34,8 +77,18 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_28_135144) do
     t.boolean "admin", default: false
     t.string "department"
     t.string "remember_digest"
+    t.bigint "manager_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["manager_id"], name: "index_users_on_manager_id"
   end
 
+  add_foreign_key "attendance_change_requests", "attendances"
+  add_foreign_key "attendance_change_requests", "users", column: "approver_id"
+  add_foreign_key "attendance_change_requests", "users", column: "requester_id"
   add_foreign_key "attendances", "users"
+  add_foreign_key "monthly_approvals", "users"
+  add_foreign_key "monthly_approvals", "users", column: "approver_id"
+  add_foreign_key "overtime_requests", "users"
+  add_foreign_key "overtime_requests", "users", column: "approver_id"
+  add_foreign_key "users", "users", column: "manager_id"
 end

--- a/spec/factories/attendance_change_requests.rb
+++ b/spec/factories/attendance_change_requests.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :attendance_change_request do
+    attendance { nil }
+    requester { nil }
+    approver { nil }
+    original_started_at { "2025-10-03 07:34:43" }
+    original_finished_at { "2025-10-03 07:34:43" }
+    requested_started_at { "2025-10-03 07:34:43" }
+    requested_finished_at { "2025-10-03 07:34:43" }
+    status { 1 }
+  end
+end

--- a/spec/factories/monthly_approvals.rb
+++ b/spec/factories/monthly_approvals.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :monthly_approval do
+    user { nil }
+    approver { nil }
+    target_month { "2025-10-03" }
+    status { 1 }
+    approved_at { "2025-10-03 07:34:13" }
+  end
+end

--- a/spec/factories/overtime_requests.rb
+++ b/spec/factories/overtime_requests.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :overtime_request do
+    user { nil }
+    approver { nil }
+    worked_on { "2025-10-03" }
+    estimated_end_time { "2025-10-03 07:34:52" }
+    business_content { "MyText" }
+    next_day_flag { false }
+    status { 1 }
+  end
+end

--- a/spec/models/attendance_change_request_spec.rb
+++ b/spec/models/attendance_change_request_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe AttendanceChangeRequest, type: :model do
+  describe 'アソシエーション' do
+    it 'attendanceに属していること' do
+      expect(AttendanceChangeRequest.reflect_on_association(:attendance).macro).to eq :belongs_to
+    end
+
+    it 'requesterに属していること' do
+      expect(AttendanceChangeRequest.reflect_on_association(:requester).macro).to eq :belongs_to
+      expect(AttendanceChangeRequest.reflect_on_association(:requester).options[:class_name]).to eq 'User'
+    end
+
+    it 'approverに属していること' do
+      expect(AttendanceChangeRequest.reflect_on_association(:approver).macro).to eq :belongs_to
+      expect(AttendanceChangeRequest.reflect_on_association(:approver).options[:class_name]).to eq 'User'
+    end
+  end
+
+  describe 'バリデーション' do
+    let(:user) { User.create(name: "申請者", email: "requester@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:attendance) { user.attendances.create(worked_on: Date.today, started_at: Time.current) }
+    let(:request) do
+      AttendanceChangeRequest.new(
+        attendance: attendance,
+        requester: user,
+        approver: approver,
+        original_started_at: Time.current,
+        original_finished_at: Time.current + 8.hours,
+        requested_started_at: Time.current + 1.hour,
+        requested_finished_at: Time.current + 9.hours
+      )
+    end
+
+    it '有効な勤怠変更申請が作成できること' do
+      expect(request).to be_valid
+    end
+
+    it 'attendanceが必須であること' do
+      request.attendance = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'requesterが必須であること' do
+      request.requester = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'approverが必須であること' do
+      request.approver = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'original_started_atが必須であること' do
+      request.original_started_at = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'original_finished_atが必須であること' do
+      request.original_finished_at = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'requested_started_atが必須であること' do
+      request.requested_started_at = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'requested_finished_atが必須であること' do
+      request.requested_finished_at = nil
+      expect(request).not_to be_valid
+    end
+  end
+
+  describe 'ステータス管理' do
+    let(:user) { User.create(name: "申請者", email: "requester@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:attendance) { user.attendances.create(worked_on: Date.today, started_at: Time.current) }
+    let(:request) do
+      AttendanceChangeRequest.create(
+        attendance: attendance,
+        requester: user,
+        approver: approver,
+        original_started_at: Time.current,
+        original_finished_at: Time.current + 8.hours,
+        requested_started_at: Time.current + 1.hour,
+        requested_finished_at: Time.current + 9.hours
+      )
+    end
+
+    it 'デフォルトステータスはpendingであること' do
+      expect(request.status).to eq 'pending'
+    end
+
+    it 'ステータスをapprovedに変更できること' do
+      request.approved!
+      expect(request.status).to eq 'approved'
+    end
+
+    it 'ステータスをrejectedに変更できること' do
+      request.rejected!
+      expect(request.status).to eq 'rejected'
+    end
+  end
+end

--- a/spec/models/attendance_change_request_spec.rb
+++ b/spec/models/attendance_change_request_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe AttendanceChangeRequest, type: :model do
     let(:attendance) { user.attendances.create(worked_on: Date.today, started_at: Time.current) }
     let(:request) do
       AttendanceChangeRequest.new(
-        attendance: attendance,
+        attendance:,
         requester: user,
-        approver: approver,
+        approver:,
         original_started_at: Time.current,
         original_finished_at: Time.current + 8.hours,
         requested_started_at: Time.current + 1.hour,
@@ -79,9 +79,9 @@ RSpec.describe AttendanceChangeRequest, type: :model do
     let(:attendance) { user.attendances.create(worked_on: Date.today, started_at: Time.current) }
     let(:request) do
       AttendanceChangeRequest.create(
-        attendance: attendance,
+        attendance:,
         requester: user,
-        approver: approver,
+        approver:,
         original_started_at: Time.current,
         original_finished_at: Time.current + 8.hours,
         requested_started_at: Time.current + 1.hour,

--- a/spec/models/monthly_approval_spec.rb
+++ b/spec/models/monthly_approval_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe MonthlyApproval, type: :model do
     let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
     let(:approval) do
       MonthlyApproval.new(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         target_month: Date.today.beginning_of_month
       )
     end
@@ -44,14 +44,14 @@ RSpec.describe MonthlyApproval, type: :model do
 
     it '同じユーザー・月の組み合わせは一意であること' do
       MonthlyApproval.create!(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         target_month: Date.today.beginning_of_month
       )
 
       duplicate = MonthlyApproval.new(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         target_month: Date.today.beginning_of_month
       )
 
@@ -64,8 +64,8 @@ RSpec.describe MonthlyApproval, type: :model do
     let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
     let(:approval) do
       MonthlyApproval.create(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         target_month: Date.today.beginning_of_month
       )
     end
@@ -90,8 +90,8 @@ RSpec.describe MonthlyApproval, type: :model do
     let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
     let(:approval) do
       MonthlyApproval.create(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         target_month: Date.today.beginning_of_month
       )
     end

--- a/spec/models/monthly_approval_spec.rb
+++ b/spec/models/monthly_approval_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe MonthlyApproval, type: :model do
+  describe 'アソシエーション' do
+    it 'userに属していること' do
+      expect(MonthlyApproval.reflect_on_association(:user).macro).to eq :belongs_to
+    end
+
+    it 'approverに属していること' do
+      expect(MonthlyApproval.reflect_on_association(:approver).macro).to eq :belongs_to
+      expect(MonthlyApproval.reflect_on_association(:approver).options[:class_name]).to eq 'User'
+    end
+  end
+
+  describe 'バリデーション' do
+    let(:user) { User.create(name: "一般", email: "user@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:approval) do
+      MonthlyApproval.new(
+        user: user,
+        approver: approver,
+        target_month: Date.today.beginning_of_month
+      )
+    end
+
+    it '有効な月次承認が作成できること' do
+      expect(approval).to be_valid
+    end
+
+    it 'userが必須であること' do
+      approval.user = nil
+      expect(approval).not_to be_valid
+    end
+
+    it 'approverが必須であること' do
+      approval.approver = nil
+      expect(approval).not_to be_valid
+    end
+
+    it 'target_monthが必須であること' do
+      approval.target_month = nil
+      expect(approval).not_to be_valid
+    end
+
+    it '同じユーザー・月の組み合わせは一意であること' do
+      MonthlyApproval.create!(
+        user: user,
+        approver: approver,
+        target_month: Date.today.beginning_of_month
+      )
+
+      duplicate = MonthlyApproval.new(
+        user: user,
+        approver: approver,
+        target_month: Date.today.beginning_of_month
+      )
+
+      expect(duplicate).not_to be_valid
+    end
+  end
+
+  describe 'ステータス管理' do
+    let(:user) { User.create(name: "一般", email: "user@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:approval) do
+      MonthlyApproval.create(
+        user: user,
+        approver: approver,
+        target_month: Date.today.beginning_of_month
+      )
+    end
+
+    it 'デフォルトステータスはpendingであること' do
+      expect(approval.status).to eq 'pending'
+    end
+
+    it 'ステータスをapprovedに変更できること' do
+      approval.approved!
+      expect(approval.status).to eq 'approved'
+    end
+
+    it 'ステータスをrejectedに変更できること' do
+      approval.rejected!
+      expect(approval.status).to eq 'rejected'
+    end
+  end
+
+  describe '#approve!' do
+    let(:user) { User.create(name: "一般", email: "user@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:approval) do
+      MonthlyApproval.create(
+        user: user,
+        approver: approver,
+        target_month: Date.today.beginning_of_month
+      )
+    end
+
+    it 'ステータスをapprovedに変更し、承認日時を記録すること' do
+      approval.approve!
+      expect(approval.status).to eq 'approved'
+      expect(approval.approved_at).not_to be_nil
+    end
+  end
+end

--- a/spec/models/overtime_request_spec.rb
+++ b/spec/models/overtime_request_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe OvertimeRequest, type: :model do
     let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
     let(:request) do
       OvertimeRequest.new(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         worked_on: Date.today,
         estimated_end_time: Time.current + 2.hours,
         business_content: "システムメンテナンス作業"
@@ -60,8 +60,8 @@ RSpec.describe OvertimeRequest, type: :model do
     let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
     let(:request) do
       OvertimeRequest.create(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         worked_on: Date.today,
         estimated_end_time: Time.current + 2.hours,
         business_content: "システムメンテナンス作業"
@@ -88,8 +88,8 @@ RSpec.describe OvertimeRequest, type: :model do
     let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
     let(:request) do
       OvertimeRequest.create(
-        user: user,
-        approver: approver,
+        user:,
+        approver:,
         worked_on: Date.today,
         estimated_end_time: Time.current + 2.hours,
         business_content: "システムメンテナンス作業"

--- a/spec/models/overtime_request_spec.rb
+++ b/spec/models/overtime_request_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe OvertimeRequest, type: :model do
+  describe 'アソシエーション' do
+    it 'userに属していること' do
+      expect(OvertimeRequest.reflect_on_association(:user).macro).to eq :belongs_to
+    end
+
+    it 'approverに属していること' do
+      expect(OvertimeRequest.reflect_on_association(:approver).macro).to eq :belongs_to
+      expect(OvertimeRequest.reflect_on_association(:approver).options[:class_name]).to eq 'User'
+    end
+  end
+
+  describe 'バリデーション' do
+    let(:user) { User.create(name: "申請者", email: "user@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:request) do
+      OvertimeRequest.new(
+        user: user,
+        approver: approver,
+        worked_on: Date.today,
+        estimated_end_time: Time.current + 2.hours,
+        business_content: "システムメンテナンス作業"
+      )
+    end
+
+    it '有効な残業申請が作成できること' do
+      expect(request).to be_valid
+    end
+
+    it 'userが必須であること' do
+      request.user = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'approverが必須であること' do
+      request.approver = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'worked_onが必須であること' do
+      request.worked_on = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'estimated_end_timeが必須であること' do
+      request.estimated_end_time = nil
+      expect(request).not_to be_valid
+    end
+
+    it 'business_contentが必須であること' do
+      request.business_content = nil
+      expect(request).not_to be_valid
+    end
+  end
+
+  describe 'ステータス管理' do
+    let(:user) { User.create(name: "申請者", email: "user@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:request) do
+      OvertimeRequest.create(
+        user: user,
+        approver: approver,
+        worked_on: Date.today,
+        estimated_end_time: Time.current + 2.hours,
+        business_content: "システムメンテナンス作業"
+      )
+    end
+
+    it 'デフォルトステータスはpendingであること' do
+      expect(request.status).to eq 'pending'
+    end
+
+    it 'ステータスをapprovedに変更できること' do
+      request.approved!
+      expect(request.status).to eq 'approved'
+    end
+
+    it 'ステータスをrejectedに変更できること' do
+      request.rejected!
+      expect(request.status).to eq 'rejected'
+    end
+  end
+
+  describe 'next_day_flag' do
+    let(:user) { User.create(name: "申請者", email: "user@example.com", password: "password") }
+    let(:approver) { User.create(name: "承認者", email: "approver@example.com", password: "password") }
+    let(:request) do
+      OvertimeRequest.create(
+        user: user,
+        approver: approver,
+        worked_on: Date.today,
+        estimated_end_time: Time.current + 2.hours,
+        business_content: "システムメンテナンス作業"
+      )
+    end
+
+    it 'デフォルトはfalseであること' do
+      expect(request.next_day_flag).to be false
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe User, type: :model do
     describe '#manager?' do
       context '部下がいる場合' do
         let(:manager) { User.create(name: "上長", email: "manager@example.com", password: "password") }
-        let!(:subordinate) { User.create(name: "部下", email: "subordinate@example.com", password: "password", manager: manager) }
+        let!(:subordinate) do
+          User.create(name: "部下", email: "subordinate@example.com", password: "password", manager:)
+        end
 
         it 'trueを返すこと' do
           expect(manager.manager?).to be true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,6 +37,43 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '組織階層のアソシエーション' do
+    describe 'belongs_to :manager' do
+      it 'managerとのアソシエーションが正しく設定されていること' do
+        expect(User.reflect_on_association(:manager).macro).to eq :belongs_to
+        expect(User.reflect_on_association(:manager).options[:class_name]).to eq 'User'
+        expect(User.reflect_on_association(:manager).options[:optional]).to be true
+      end
+    end
+
+    describe 'has_many :subordinates' do
+      it 'subordinatesとのアソシエーションが正しく設定されていること' do
+        expect(User.reflect_on_association(:subordinates).macro).to eq :has_many
+        expect(User.reflect_on_association(:subordinates).options[:class_name]).to eq 'User'
+        expect(User.reflect_on_association(:subordinates).options[:foreign_key]).to eq :manager_id
+      end
+    end
+
+    describe '#manager?' do
+      context '部下がいる場合' do
+        let(:manager) { User.create(name: "上長", email: "manager@example.com", password: "password") }
+        let!(:subordinate) { User.create(name: "部下", email: "subordinate@example.com", password: "password", manager: manager) }
+
+        it 'trueを返すこと' do
+          expect(manager.manager?).to be true
+        end
+      end
+
+      context '部下がいない場合' do
+        let(:user) { User.create(name: "一般", email: "general@example.com", password: "password") }
+
+        it 'falseを返すこと' do
+          expect(user.manager?).to be false
+        end
+      end
+    end
+  end
+
   describe 'remember機能' do
     let(:user) { User.create(name: "テスト太郎", email: "test@example.com", password: "password") }
 


### PR DESCRIPTION
## Summary
承認ワークフローシステムのデータモデル基盤を構築しました。

## 実装内容

### 📊 新規モデル（4つ）

#### 1. User組織階層機能
- `manager_id`による自己参照関係
- `belongs_to :manager` / `has_many :subordinates`
- `manager?`メソッド（部下の有無判定）

#### 2. MonthlyApproval（月次勤怠承認）
- 月次勤怠の承認申請管理
- `user_id` + `target_month`の一意制約
- `approve!`メソッド（承認処理）

#### 3. AttendanceChangeRequest（勤怠変更申請）
- 勤怠時刻の変更申請管理
- 変更前後の時刻を保持（original/requested）
- requester（申請者）/ approver（承認者）

#### 4. OvertimeRequest（残業申請）
- 残業申請管理
- 業務内容、終業予定時刻
- 翌日フラグ（next_day_flag）

### 🔧 技術仕様

**共通機能**
- enum status: `pending` / `approved` / `rejected`
- 外部キー制約による整合性保証
- approver → users テーブルへの参照

**データ整合性**
- NOT NULL制約
- UNIQUE制約（月次承認）
- デフォルト値設定

### ✅ テスト結果

**新規モデルのテスト**
- ✅ User: 14 examples, 0 failures
- ✅ MonthlyApproval: 11 examples, 0 failures  
- ✅ AttendanceChangeRequest: 14 examples, 0 failures
- ✅ OvertimeRequest: 12 examples, 0 failures

**品質**
- ✅ RuboCop: no offenses detected
- ✅ TDD方式で実装（RED → GREEN → REFACTOR）
- ✅ カバレッジ: 91.33%

### 📝 コミット履歴
1. ✅ Userモデルに組織階層機能を追加
2. ✅ MonthlyApprovalモデルを追加
3. ✅ AttendanceChangeRequestモデルを追加
4. ✅ OvertimeRequestモデルを追加
5. ✅ schema.rbを更新（承認機能モデル追加反映）
6. ✅ RuboCop違反を修正（Hash省略記法に対応）

## ⚠️ CI状況について

### 既存テスト失敗（1件）
- `UserPageRedesign` の勤怠登録ボタン表示テスト
- **今回のPRとは無関係**な既存の問題（Feature/21以降から存在）
- **マージ影響なし**（データモデル層のみの変更のため）

### 対応方針
次のPR（Feature/23）で既存テスト修復を行います：
- [ ] UserPageRedesignテストの修正
- [ ] ビューの勤怠登録ボタン実装確認
- [ ] CI完全グリーン化

## Test plan
- [x] マイグレーション実行成功
- [x] 全モデルのRSpecテストがパス
- [x] RuboCop品質チェック通過
- [x] 外部キー制約の動作確認
- [x] 新規モデルのカバレッジ確認

## 変更ファイル
16 files changed, 531 insertions(+), 1 deletion(-)

## 次のステップ
- Feature/23: 既存テスト修復
- Feature/24~: 承認機能UI実装（コントローラー・ビュー）

🤖 Generated with [Claude Code](https://claude.com/claude-code)