### PR TITLE
Feature/24: 月次勤怠承認申請機能（基盤実装）

### DIFF
--- a/app/controllers/monthly_approvals_controller.rb
+++ b/app/controllers/monthly_approvals_controller.rb
@@ -1,0 +1,41 @@
+class MonthlyApprovalsController < ApplicationController
+  before_action :logged_in_user
+  before_action :set_user
+
+  def create
+    # 既存の申請があれば上書き（再承認対応）
+    @approval = @user.monthly_approvals.find_or_initialize_by(
+      target_month: approval_params[:target_month]
+    )
+
+    @approval.approver_id = approval_params[:approver_id]
+    @approval.status = :pending
+    @approval.approved_at = nil
+
+    set_flash_message
+    redirect_to @user
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+
+  def set_flash_message
+    if @approval.save
+      flash[:success] = "#{format_target_month}の勤怠を申請しました。"
+    else
+      flash[:danger] = "申請に失敗しました: #{@approval.errors.full_messages.join(', ')}"
+    end
+  end
+
+  def format_target_month
+    month = @approval.target_month.is_a?(Date) ? @approval.target_month : Date.parse(@approval.target_month.to_s)
+    l(month, format: :middle)
+  end
+
+  def approval_params
+    params.require(:monthly_approval).permit(:approver_id, :target_month)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,11 @@ class User < ApplicationRecord
   belongs_to :manager, class_name: 'User', optional: true
   has_many :subordinates, class_name: 'User', foreign_key: :manager_id
 
+  # 承認申請
+  has_many :monthly_approvals, dependent: :destroy
+  has_many :attendance_change_requests, foreign_key: :requester_id, dependent: :destroy
+  has_many :overtime_requests, dependent: :destroy
+
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,26 +35,6 @@
   <% end %>
 </div>
 
-<!-- 所属長承認申請セクション -->
-<div class="approval-section" style="margin-top: 20px; padding: 15px; border: 1px solid #ddd; border-radius: 4px;">
-  <h4>所属長承認申請</h4>
-  <%= form_with model: MonthlyApproval.new, url: user_monthly_approvals_path(@user), local: true do |f| %>
-    <%= f.hidden_field :target_month, value: @first_day %>
-
-    <div class="form-group">
-      <%= f.label :approver_id, "承認者を選択" %>
-      <%= f.select :approver_id,
-          options_from_collection_for_select(User.where.not(id: @user.id), :id, :name, @user.manager_id),
-          { prompt: "承認者を選択してください" },
-          class: "form-control" %>
-    </div>
-
-    <div class="form-group" style="margin-top: 10px;">
-      <%= f.submit "申請", class: "btn btn-primary" %>
-    </div>
-  <% end %>
-</div>
-
 <!-- モーダルコンテナ -->
 <div id="basic-info-modal" class="modal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1050; background-color: rgba(0,0,0,0.3);">
   <div class="modal-dialog" style="position: relative; width: auto; margin: 10px auto; max-width: 600px; top: 50%; transform: translateY(-50%);">
@@ -337,6 +317,26 @@ window.closeModal = closeModal;
       </tr>
     </tfoot>
   </table>
+</div>
+
+<!-- 所属長承認申請セクション -->
+<div class="approval-section" style="margin-top: 20px; padding: 15px; border: 1px solid #ddd; border-radius: 4px;">
+  <h4>所属長承認</h4>
+  <%= form_with model: MonthlyApproval.new, url: user_monthly_approvals_path(@user), local: true do |f| %>
+    <%= f.hidden_field :target_month, value: @first_day %>
+
+    <div class="form-group">
+      <%= f.label :approver_id, "承認者を選択" %>
+      <%= f.select :approver_id,
+          options_from_collection_for_select(User.where.not(id: @user.id), :id, :name, @user.manager_id),
+          { prompt: "承認者を選択してください" },
+          class: "form-control" %>
+    </div>
+
+    <div class="form-group" style="margin-top: 10px;">
+      <%= f.submit "申請", class: "btn btn-primary" %>
+    </div>
+  <% end %>
 </div>
 
 <!-- 土日色分けスタイル -->

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,6 +35,26 @@
   <% end %>
 </div>
 
+<!-- 所属長承認申請セクション -->
+<div class="approval-section" style="margin-top: 20px; padding: 15px; border: 1px solid #ddd; border-radius: 4px;">
+  <h4>所属長承認申請</h4>
+  <%= form_with model: MonthlyApproval.new, url: user_monthly_approvals_path(@user), local: true do |f| %>
+    <%= f.hidden_field :target_month, value: @first_day %>
+
+    <div class="form-group">
+      <%= f.label :approver_id, "承認者を選択" %>
+      <%= f.select :approver_id,
+          options_from_collection_for_select(User.where.not(id: @user.id), :id, :name, @user.manager_id),
+          { prompt: "承認者を選択してください" },
+          class: "form-control" %>
+    </div>
+
+    <div class="form-group" style="margin-top: 10px;">
+      <%= f.submit "申請", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>
+
 <!-- モーダルコンテナ -->
 <div id="basic-info-modal" class="modal" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 1050; background-color: rgba(0,0,0,0.3);">
   <div class="modal-dialog" style="position: relative; width: auto; margin: 10px auto; max-width: 600px; top: 50%; transform: translateY(-50%);">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -322,7 +322,7 @@ window.closeModal = closeModal;
 <!-- 所属長承認申請セクション -->
 <div class="approval-section" style="margin-top: 20px; padding: 15px; border: 1px solid #ddd; border-radius: 4px;">
   <h4>所属長承認</h4>
-  <%= form_with model: MonthlyApproval.new, url: user_monthly_approvals_path(@user), local: true do |f| %>
+  <%= form_with model: MonthlyApproval.new, url: user_monthly_approvals_path(@user), local: true, id: "approval-form" do |f| %>
     <%= f.hidden_field :target_month, value: @first_day %>
 
     <div class="form-group">
@@ -338,6 +338,44 @@ window.closeModal = closeModal;
     </div>
   <% end %>
 </div>
+
+<!-- 所属長承認申請確認ダイアログ -->
+<script>
+document.addEventListener('turbo:load', function() {
+  initializeApprovalConfirmation();
+});
+
+document.addEventListener('DOMContentLoaded', function() {
+  initializeApprovalConfirmation();
+});
+
+function initializeApprovalConfirmation() {
+  const form = document.getElementById('approval-form');
+
+  if (form) {
+    form.removeEventListener('submit', handleApprovalSubmit);
+    form.addEventListener('submit', handleApprovalSubmit);
+  }
+}
+
+function handleApprovalSubmit(e) {
+  const approverSelect = document.querySelector('#approval-form select[name="monthly_approval[approver_id]"]');
+  const approverName = approverSelect.options[approverSelect.selectedIndex].text;
+
+  if (approverSelect.value === '') {
+    alert('承認者を選択してください。');
+    e.preventDefault();
+    return false;
+  }
+
+  const message = `${approverName} に勤怠を申請します。よろしいですか？`;
+
+  if (!confirm(message)) {
+    e.preventDefault();
+    return false;
+  }
+}
+</script>
 
 <!-- 土日色分けスタイル -->
 <style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         patch 'update_one_month'
       end
     end
+    resources :monthly_approvals, only: [:create]
   end
 
   # ヘルスチェック用

--- a/spec/requests/monthly_approvals_spec.rb
+++ b/spec/requests/monthly_approvals_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "MonthlyApprovals", type: :request do
+  let(:user) { User.create!(name: "申請者", email: "user@example.com", password: "password") }
+  let(:approver) { User.create!(name: "承認者", email: "approver@example.com", password: "password") }
+  let(:target_month) { Date.current.beginning_of_month }
+
+  before do
+    post login_path, params: { session: { email: user.email, password: "password" } }
+  end
+
+  describe "POST /users/:user_id/monthly_approvals" do
+    context "有効なパラメータの場合" do
+      it "新しい月次承認申請が作成されること" do
+        expect do
+          post user_monthly_approvals_path(user), params: {
+            monthly_approval: {
+              approver_id: approver.id,
+              target_month:
+            }
+          }
+        end.to change(MonthlyApproval, :count).by(1)
+      end
+
+      it "ステータスがpendingに設定されること" do
+        post user_monthly_approvals_path(user), params: {
+          monthly_approval: {
+            approver_id: approver.id,
+            target_month:
+          }
+        }
+        expect(MonthlyApproval.last.status).to eq 'pending'
+      end
+
+      it "成功メッセージが表示されること" do
+        post user_monthly_approvals_path(user), params: {
+          monthly_approval: {
+            approver_id: approver.id,
+            target_month:
+          }
+        }
+        expect(flash[:success]).to be_present
+      end
+
+      it "ユーザー詳細ページにリダイレクトされること" do
+        post user_monthly_approvals_path(user), params: {
+          monthly_approval: {
+            approver_id: approver.id,
+            target_month:
+          }
+        }
+        expect(response).to redirect_to user_path(user)
+      end
+    end
+
+    context "既存の申請がある場合（再承認）" do
+      before do
+        MonthlyApproval.create!(
+          user:,
+          approver:,
+          target_month:,
+          status: :approved,
+          approved_at: Time.current
+        )
+      end
+
+      it "既存レコードが上書きされること" do
+        expect do
+          post user_monthly_approvals_path(user), params: {
+            monthly_approval: {
+              approver_id: approver.id,
+              target_month:
+            }
+          }
+        end.not_to change(MonthlyApproval, :count)
+      end
+
+      it "ステータスがpendingにリセットされること" do
+        post user_monthly_approvals_path(user), params: {
+          monthly_approval: {
+            approver_id: approver.id,
+            target_month:
+          }
+        }
+        expect(MonthlyApproval.last.status).to eq 'pending'
+      end
+
+      it "approved_atがnilにリセットされること" do
+        post user_monthly_approvals_path(user), params: {
+          monthly_approval: {
+            approver_id: approver.id,
+            target_month:
+          }
+        }
+        expect(MonthlyApproval.last.approved_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
月次勤怠承認申請機能を実装しました。ユーザーが上長に対して月次勤怠の承認を申請できる機能です。

## 実装内容

### 1. ルーティング追加
```ruby
resources :users do
  resources :monthly_approvals, only: [:create]
end
```
- `POST /users/:user_id/monthly_approvals` - 月次承認申請の作成

### 2. MonthlyApprovalsController
**主要機能**:
- 既存申請の上書き対応（再承認機能）
  - `find_or_initialize_by(target_month:)` で同一月の申請を検索
  - 既存の場合は上書き、新規の場合は作成
- ステータス初期化: `pending`
- 承認日時リセット: `approved_at = nil`

**リファクタリング実施**:
```ruby
# Before: AbcSize 26.13 (許容値 17)
def create
  # 複雑なロジックが全て1メソッドに
end

# After: AbcSize クリア
def create
  # シンプルな制御フロー
  set_flash_message
  redirect_to @user
end

private

def set_flash_message
  # フラッシュメッセージ設定を分離
end

def format_target_month
  # 日付フォーマット処理を分離
end
```

### 3. Userモデル拡張
承認申請関連のアソシエーション追加:
```ruby
# 承認申請
has_many :monthly_approvals, dependent: :destroy
has_many :attendance_change_requests, foreign_key: :requester_id, dependent: :destroy
has_many :overtime_requests, dependent: :destroy
```

### 4. UI実装（users/show.html.erb）
**所属長承認申請セクション追加**:
- 承認者選択ドロップダウン
  - 自分以外の全ユーザーから選択可能
  - デフォルトで自分のmanagerを選択
- 申請ボタン
- 対象月: 現在表示中の月（`@first_day`）

**確認ダイアログ実装**:
- 申請ボタン押下時に確認ダイアログ表示
- 承認者未選択時のバリデーション（alert）
- 承認者名を含む確認メッセージ: `「○○さん に勤怠を申請します。よろしいですか？」`
- Turbo対応のイベントリスナー設定

### 5. テスト実装
**テストケース（全7件）**:
1. ✅ 新しい月次承認申請が作成されること
2. ✅ ステータスがpendingに設定されること
3. ✅ 成功メッセージが表示されること
4. ✅ ユーザー詳細ページにリダイレクトされること
5. ✅ 既存レコードが上書きされること（再承認）
6. ✅ ステータスがpendingにリセットされること（再承認）
7. ✅ approved_atがnilにリセットされること（再承認）

## テスト結果

### RSpec
```
7 examples, 0 failures
```

### RuboCop
```
74 files inspected, no offenses detected
```

## ビジネスロジック

### 再承認対応
カリキュラム仕様「一度承認されたものを再度承認可能」を実装:
1. 同一ユーザー・同一月の申請を検索
2. 既存の場合: ステータスを`pending`にリセット、`approved_at`を`nil`に
3. 新規の場合: 新規作成

### 誤操作防止
確認ダイアログによる二段階確認で誤申請を防止:
1. 承認者選択の必須チェック
2. 承認者名を明示した確認メッセージ
3. キャンセル可能な設計

## 影響範囲
- 新規ファイル: `MonthlyApprovalsController`, テストファイル
- 既存ファイル修正: `User`モデル（アソシエーション追加）、`users/show.html.erb`（UI追加、ダイアログ追加）
- 破壊的変更: なし

## 関連PR
- #25 (Feature/22) - データモデル基盤構築
- #26 (Feature/23) - 既存テスト修復

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>