### PR TITLE
Feature/30: 残業承認モーダル実装 & 承認UI統一

### DIFF
--- a/app/controllers/monthly_approvals_controller.rb
+++ b/app/controllers/monthly_approvals_controller.rb
@@ -4,7 +4,7 @@ class MonthlyApprovalsController < ApplicationController
   before_action :require_manager, only: %i[index bulk_update]
 
   def index
-    @approvals = MonthlyApproval.pending.where(approver: current_user)
+    @approvals = MonthlyApproval.pending.where(approver: current_user).includes(:user)
 
     return unless request.xhr?
 
@@ -72,7 +72,7 @@ class MonthlyApprovalsController < ApplicationController
   end
 
   def render_no_selection_error
-    @approvals = MonthlyApproval.pending.where(approver: current_user)
+    @approvals = MonthlyApproval.pending.where(approver: current_user).includes(:user)
     flash.now[:alert] = '承認する項目を選択してください'
     render :index, layout: false, status: :unprocessable_entity
   end
@@ -85,7 +85,7 @@ class MonthlyApprovalsController < ApplicationController
   end
 
   def render_pending_status_error
-    @approvals = MonthlyApproval.pending.where(approver: current_user)
+    @approvals = MonthlyApproval.pending.where(approver: current_user).includes(:user)
     flash.now[:alert] = '承認または否認を選択してください'
     render :index, layout: false, status: :unprocessable_entity
   end
@@ -107,7 +107,7 @@ class MonthlyApprovalsController < ApplicationController
   end
 
   def handle_bulk_update_error(error)
-    @approvals = MonthlyApproval.pending.where(approver: current_user)
+    @approvals = MonthlyApproval.pending.where(approver: current_user).includes(:user)
     flash.now[:alert] = "エラーが発生しました: #{error.message}"
     render :index, layout: false, status: :unprocessable_entity
   end

--- a/app/controllers/overtime_approvals_controller.rb
+++ b/app/controllers/overtime_approvals_controller.rb
@@ -1,0 +1,78 @@
+class OvertimeApprovalsController < ApplicationController
+  before_action :logged_in_user
+  before_action :require_manager, only: %i[index bulk_update]
+
+  def index
+    @requests = OvertimeRequest.pending.where(approver: current_user).includes(:user)
+
+    return unless request.xhr?
+
+    render layout: false
+  end
+
+  def bulk_update
+    selected_requests = extract_selected_requests
+
+    return render_no_selection_error if selected_requests.empty?
+    return render_pending_status_error if pending_status?(selected_requests)
+
+    process_bulk_update(selected_requests)
+    handle_bulk_update_success
+  rescue ActiveRecord::RecordInvalid => e
+    handle_bulk_update_error(e)
+  end
+
+  private
+
+  def require_manager
+    return if current_user.manager?
+
+    redirect_to root_path, alert: '管理者権限が必要です'
+  end
+
+  def extract_selected_requests
+    request_params = params[:requests] || {}
+    request_params.select { |_id, attrs| attrs[:selected] == '1' }
+  end
+
+  def render_no_selection_error
+    @requests = OvertimeRequest.pending.where(approver: current_user).includes(:user)
+    flash.now[:alert] = '承認する項目を選択してください'
+    render :index, layout: false, status: :unprocessable_entity
+  end
+
+  def pending_status?(selected_requests)
+    selected_requests.any? { |_id, attrs| attrs[:status] == 'pending' }
+  rescue NoMethodError
+    # ActionController::Parametersの場合
+    selected_requests.each.any? { |_id, attrs| attrs[:status] == 'pending' }
+  end
+
+  def render_pending_status_error
+    @requests = OvertimeRequest.pending.where(approver: current_user).includes(:user)
+    flash.now[:alert] = '承認または否認を選択してください'
+    render :index, layout: false, status: :unprocessable_entity
+  end
+
+  def process_bulk_update(selected_requests)
+    OvertimeRequest.transaction do
+      selected_requests.each do |id, attrs|
+        request_record = OvertimeRequest.find_by(id:, approver: current_user)
+        next unless request_record
+
+        request_record.update!(status: attrs[:status])
+      end
+    end
+  end
+
+  def handle_bulk_update_success
+    flash[:success] = '承認処理が完了しました'
+    redirect_to user_path(current_user)
+  end
+
+  def handle_bulk_update_error(error)
+    @requests = OvertimeRequest.pending.where(approver: current_user).includes(:user)
+    flash.now[:alert] = "エラーが発生しました: #{error.message}"
+    render :index, layout: false, status: :unprocessable_entity
+  end
+end

--- a/app/views/monthly_approvals/index.html.erb
+++ b/app/views/monthly_approvals/index.html.erb
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <h4 class="modal-title">申請者からの1ヶ月分の勤怠申請</h4>
+  <h4 class="modal-title">所属長承認申請の承認</h4>
   <button type="button" class="close" data-action="modal#close">&times;</button>
 </div>
 
@@ -26,43 +26,48 @@
               } do |f| %>
   <div class="modal-body">
     <% if @approvals.any? %>
-      <table class="table table-bordered table-striped">
-        <thead>
-          <tr>
-            <th>月</th>
-            <th>指示者確認印</th>
-            <th>変更</th>
-            <th>勤怠を確認する</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @approvals.each do |approval| %>
+      <% @approvals.group_by(&:user).each do |user, approvals| %>
+        <h5 style="margin-top: 20px; margin-bottom: 10px; padding: 10px; background-color: #f5f5f5; border-left: 4px solid #337ab7;">
+          【<%= user.name %>さんからの申請】
+        </h5>
+        <table class="table table-bordered table-striped" style="margin-bottom: 30px;">
+          <thead>
             <tr>
-              <td><%= l(approval.target_month, format: :middle) %></td>
-              <td>
-                <%= f.select "approvals[#{approval.id}][status]",
-                    options_for_select([
-                      ['申請中', 'pending'],
-                      ['承認', 'approved'],
-                      ['否認', 'rejected']
-                    ], approval.status),
-                    {},
-                    class: "form-control" %>
-              </td>
-              <td class="text-center">
-                <%= f.check_box "approvals[#{approval.id}][selected]", {}, '1', '0' %>
-              </td>
-              <td class="text-center">
-                <%= link_to "確認",
-                    user_path(approval.user, month: approval.target_month),
-                    target: "_blank",
-                    rel: "noopener noreferrer",
-                    class: "btn btn-info btn-sm" %>
-              </td>
+              <th>月</th>
+              <th>承認/否認</th>
+              <th>変更</th>
+              <th>勤怠確認</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% approvals.each do |approval| %>
+              <tr>
+                <td><%= l(approval.target_month, format: :middle) %></td>
+                <td>
+                  <%= f.select "approvals[#{approval.id}][status]",
+                      options_for_select([
+                        ['申請中', 'pending'],
+                        ['承認', 'approved'],
+                        ['否認', 'rejected']
+                      ], approval.status),
+                      {},
+                      class: "form-control" %>
+                </td>
+                <td class="text-center">
+                  <%= f.check_box "approvals[#{approval.id}][selected]", {}, '1', '0' %>
+                </td>
+                <td class="text-center">
+                  <%= link_to "確認",
+                      user_path(user, date: approval.target_month),
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      class: "btn btn-info btn-sm" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
     <% else %>
       <p class="text-center text-muted">承認待ちの申請はありません</p>
     <% end %>

--- a/app/views/overtime_approvals/index.html.erb
+++ b/app/views/overtime_approvals/index.html.erb
@@ -1,0 +1,103 @@
+<div class="modal-header">
+  <h4 class="modal-title">残業申請の承認</h4>
+  <button type="button" class="close" data-action="modal#close">&times;</button>
+</div>
+
+<% if flash[:notice] %>
+  <div class="alert alert-success" style="margin: 15px;">
+    <%= flash[:notice] %>
+  </div>
+<% end %>
+
+<% if flash[:alert] %>
+  <div class="alert alert-danger" style="margin: 15px;">
+    <%= flash[:alert] %>
+  </div>
+<% end %>
+
+<%= form_with url: bulk_update_overtime_approvals_path, method: :patch,
+              local: true,
+              remote: true,
+              html: {
+                data: {
+                  confirm: "true",
+                  confirm_message: "変更内容を送信してよろしいですか？"
+                }
+              } do |f| %>
+  <div class="modal-body">
+    <% if @requests.any? %>
+      <% @requests.group_by(&:user).each do |user, requests| %>
+        <h5 style="margin-top: 20px; margin-bottom: 10px; padding: 10px; background-color: #f5f5f5; border-left: 4px solid #337ab7;">
+          【<%= user.name %>さんからの申請】
+        </h5>
+        <table class="table table-bordered table-striped" style="margin-bottom: 30px;">
+          <thead>
+            <tr>
+              <th>日付</th>
+              <th>退社時刻</th>
+              <th>終了予定時間</th>
+              <th>残業時間</th>
+              <th>業務内容</th>
+              <th>承認/否認</th>
+              <th>変更</th>
+              <th>勤怠確認</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% requests.each do |overtime_request| %>
+              <% attendance = overtime_request.user.attendances.find_by(worked_on: overtime_request.worked_on) %>
+              <tr>
+                <td><%= l(overtime_request.worked_on, format: :short) %></td>
+                <td>
+                  <%= attendance&.finished_at&.strftime("%H:%M") || "-" %>
+                </td>
+                <td>
+                  <%= overtime_request.estimated_end_time&.strftime("%H:%M") %>
+                </td>
+                <td>
+                  <% if attendance&.finished_at.present? && overtime_request.estimated_end_time.present? %>
+                    <% estimated_time = Time.zone.parse("#{overtime_request.worked_on} #{overtime_request.estimated_end_time.strftime('%H:%M')}") %>
+                    <% overtime_hours = ((estimated_time - attendance.finished_at) / 3600.0).round(2) %>
+                    <%= overtime_hours %>h
+                  <% else %>
+                    -
+                  <% end %>
+                </td>
+                <td><%= overtime_request.business_content %></td>
+                <td>
+                  <%= f.select "requests[#{overtime_request.id}][status]",
+                      options_for_select([
+                        ['申請中', 'pending'],
+                        ['承認', 'approved'],
+                        ['否認', 'rejected']
+                      ], overtime_request.status),
+                      {},
+                      class: "form-control" %>
+                </td>
+                <td class="text-center">
+                  <%= f.check_box "requests[#{overtime_request.id}][selected]", {}, '1', '0' %>
+                </td>
+                <td class="text-center">
+                  <%= link_to "確認",
+                      user_path(user, date: overtime_request.worked_on.beginning_of_month),
+                      target: "_blank",
+                      rel: "noopener noreferrer",
+                      class: "btn btn-info btn-sm" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
+    <% else %>
+      <p class="text-center text-muted">承認待ちの申請はありません</p>
+    <% end %>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default" data-action="modal#close">キャンセル</button>
+    <% if @requests.any? %>
+      <%= f.submit "変更を送信する", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -50,7 +50,7 @@
     </div>
 
     <div class="notification-item">
-      <%= link_to "#", data: { action: "modal#openDummy", dummy_title: "残業申請" }, class: "notification-link" do %>
+      <%= link_to overtime_approvals_path, data: { action: "modal#open" }, class: "notification-link" do %>
         【残業申請のお知らせ】
         <% if overtime_requests_count > 0 %>
           <span class="notification-badge"><%= overtime_requests_count %>件</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   resources :monthly_approvals, only: [:index], concerns: :bulk_updatable
   resources :attendance_change_approvals, only: [:index], concerns: :bulk_updatable
+  resources :overtime_approvals, only: [:index], concerns: :bulk_updatable
 
   resources :users do
     member do

--- a/spec/requests/monthly_approvals_spec.rb
+++ b/spec/requests/monthly_approvals_spec.rb
@@ -3,21 +3,317 @@
 require 'rails_helper'
 
 RSpec.describe "MonthlyApprovals", type: :request do
-  let(:user) { User.create!(name: "申請者", email: "user@example.com", password: "password") }
-  let(:approver) { User.create!(name: "承認者", email: "approver@example.com", password: "password") }
+  # ヘルパーメソッド: 勤怠データを作成
+  def create_attendance_data(user, target_date = Date.today)
+    user.attendances.create!(
+      worked_on: target_date,
+      started_at: Time.zone.parse("#{target_date} 09:00"),
+      finished_at: Time.zone.parse("#{target_date} 18:00")
+    )
+  end
+
+  let(:subordinate) do
+    User.create!(
+      name: "部下ユーザー",
+      email: "subordinate_#{Time.current.to_i}@example.com",
+      password: "password123",
+      department: "開発部"
+    )
+  end
+
+  let(:manager) do
+    User.create!(
+      name: "マネージャー",
+      email: "manager_#{Time.current.to_i}@example.com",
+      password: "password123",
+      department: "開発部"
+    ).tap do |user|
+      subordinate.update!(manager_id: user.id)
+    end
+  end
+
+  let(:regular_user) do
+    User.create!(
+      name: "一般ユーザー",
+      email: "regular_#{Time.current.to_i}@example.com",
+      password: "password123",
+      department: "開発部"
+    )
+  end
+
   let(:target_month) { Date.current.beginning_of_month }
 
-  before do
-    # 勤怠データを作成（月次承認には勤怠データが必須）
-    user.attendances.create!(
-      worked_on: target_month,
-      started_at: Time.zone.parse("#{target_month} 09:00"),
-      finished_at: Time.zone.parse("#{target_month} 18:00")
-    )
-    post login_path, params: { session: { email: user.email, password: "password" } }
+  describe 'GET #index' do
+    context 'マネージャーとしてログインしている場合' do
+      before do
+        post login_path, params: { session: { email: manager.email, password: "password123" } }
+      end
+
+      it 'HTTPステータス200を返すこと' do
+        get monthly_approvals_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'indexテンプレートを表示すること' do
+        get monthly_approvals_path, xhr: true
+        expect(response.body).to include('所属長承認申請の承認')
+      end
+
+      it '自分が承認者となっている申請中の月次承認申請を取得すること' do
+        user1 = User.create!(name: "申請者1", email: "user1_#{Time.current.to_i}@example.com", password: "password123")
+        user2 = User.create!(name: "申請者2", email: "user2_#{Time.current.to_i}@example.com", password: "password123")
+        user_for_approved = User.create!(name: "承認済申請者", email: "approved_#{Time.current.to_i}@example.com",
+                                         password: "password123")
+
+        # 勤怠データを作成
+        create_attendance_data(user1, Date.current.beginning_of_month)
+        create_attendance_data(user2, Date.current.beginning_of_month)
+        create_attendance_data(user_for_approved, Date.current.beginning_of_month)
+
+        MonthlyApproval.create!(
+          user: user1,
+          approver: manager,
+          target_month: Date.current.beginning_of_month,
+          status: :pending
+        )
+
+        MonthlyApproval.create!(
+          user: user2,
+          approver: manager,
+          target_month: Date.current.beginning_of_month,
+          status: :pending
+        )
+
+        MonthlyApproval.create!(
+          user: user_for_approved,
+          approver: manager,
+          target_month: Date.current.beginning_of_month,
+          status: :approved
+        )
+
+        get monthly_approvals_path, xhr: true
+
+        expect(MonthlyApproval.pending.where(approver: manager).count).to eq(2)
+        expect(response.body).to include('申請者1')
+        expect(response.body).to include('申請者2')
+        expect(response.body).not_to include('承認済申請者')
+      end
+
+      it '他のマネージャー宛の月次承認申請は含まれないこと' do
+        other_manager = User.create!(name: "他マネージャー", email: "other_mgr_#{Time.current.to_i}@example.com",
+                                     password: "password123")
+        user3 = User.create!(name: "申請者3", email: "user3_#{Time.current.to_i}@example.com", password: "password123")
+
+        create_attendance_data(user3, Date.current.beginning_of_month)
+
+        MonthlyApproval.create!(
+          user: user3,
+          approver: other_manager,
+          target_month: Date.current.beginning_of_month,
+          status: :pending
+        )
+
+        get monthly_approvals_path, xhr: true
+
+        expect(MonthlyApproval.pending.where(approver: manager).count).to eq(0)
+        expect(response.body).not_to include('申請者3')
+      end
+    end
+
+    context 'マネージャー権限がない場合' do
+      before do
+        post login_path, params: { session: { email: regular_user.email, password: "password123" } }
+      end
+
+      it 'ルートパスにリダイレクトすること' do
+        get monthly_approvals_path
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'アラートメッセージを表示すること' do
+        get monthly_approvals_path
+        expect(flash[:alert]).to eq('管理者権限が必要です')
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it 'ログインページにリダイレクトすること' do
+        get monthly_approvals_path
+        expect(response).to redirect_to(login_path)
+      end
+    end
+  end
+
+  describe 'PATCH #bulk_update' do
+    context 'マネージャーとしてログインしている場合' do
+      before do
+        post login_path, params: { session: { email: manager.email, password: "password123" } }
+      end
+
+      let!(:user1) do
+        User.create!(name: "申請者1", email: "ap1_#{Time.current.to_i}@example.com", password: "password123").tap do |u|
+          create_attendance_data(u, Date.current.beginning_of_month)
+        end
+      end
+      let!(:user2) do
+        User.create!(name: "申請者2", email: "ap2_#{Time.current.to_i}@example.com", password: "password123").tap do |u|
+          create_attendance_data(u, Date.current.beginning_of_month)
+        end
+      end
+      let!(:user3) do
+        User.create!(name: "申請者3", email: "ap3_#{Time.current.to_i}@example.com", password: "password123").tap do |u|
+          create_attendance_data(u, Date.current.beginning_of_month)
+        end
+      end
+
+      let!(:approval1) do
+        MonthlyApproval.create!(
+          user: user1,
+          approver: manager,
+          target_month: Date.current.beginning_of_month,
+          status: :pending
+        )
+      end
+
+      let!(:approval2) do
+        MonthlyApproval.create!(
+          user: user2,
+          approver: manager,
+          target_month: Date.current.beginning_of_month,
+          status: :pending
+        )
+      end
+
+      let!(:approval3) do
+        MonthlyApproval.create!(
+          user: user3,
+          approver: manager,
+          target_month: Date.current.beginning_of_month,
+          status: :pending
+        )
+      end
+
+      context '有効なパラメータの場合' do
+        let(:valid_params) do
+          {
+            approvals: {
+              approval1.id.to_s => { selected: '1', status: 'approved' },
+              approval2.id.to_s => { selected: '1', status: 'rejected' },
+              approval3.id.to_s => { selected: '0', status: 'pending' }
+            }
+          }
+        end
+
+        it 'チェックされた月次承認申請のステータスを更新すること' do
+          patch bulk_update_monthly_approvals_path, params: valid_params
+
+          expect(approval1.reload.status).to eq('approved')
+          expect(approval2.reload.status).to eq('rejected')
+          expect(approval3.reload.status).to eq('pending')
+        end
+
+        it 'ユーザー詳細ページにリダイレクトして成功メッセージを表示すること' do
+          patch bulk_update_monthly_approvals_path, params: valid_params
+
+          expect(response).to redirect_to(user_path(manager))
+          expect(flash[:success]).to eq('承認処理が完了しました')
+        end
+
+        it '自分が承認者の申請のみ更新すること' do
+          other_manager = User.create!(name: "他マネージャー", email: "othmgr_#{Time.current.to_i}@example.com",
+                                       password: "password123")
+          user4 = User.create!(name: "申請者4", email: "ap4_#{Time.current.to_i}@example.com", password: "password123")
+          create_attendance_data(user4, Date.current.beginning_of_month)
+
+          other_approval = MonthlyApproval.create!(
+            user: user4,
+            approver: other_manager,
+            target_month: Date.current.beginning_of_month,
+            status: :pending
+          )
+
+          params = {
+            approvals: {
+              other_approval.id.to_s => { selected: '1', status: 'approved' }
+            }
+          }
+
+          patch(bulk_update_monthly_approvals_path, params:)
+
+          expect(other_approval.reload.status).to eq('pending')
+        end
+      end
+
+      context 'チェックされた項目がない場合' do
+        let(:no_selection_params) do
+          {
+            approvals: {
+              approval1.id.to_s => { selected: '0', status: 'approved' }
+            }
+          }
+        end
+
+        it 'アラートメッセージを表示してリダイレクトすること' do
+          patch bulk_update_monthly_approvals_path, params: no_selection_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(flash.now[:alert]).to eq('承認する項目を選択してください')
+        end
+      end
+
+      context 'チェックされているが承認/否認が選択されていない場合' do
+        let(:pending_status_params) do
+          {
+            approvals: {
+              approval1.id.to_s => { selected: '1', status: 'pending' }
+            }
+          }
+        end
+
+        it 'アラートメッセージを表示してリダイレクトすること' do
+          patch bulk_update_monthly_approvals_path, params: pending_status_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(flash.now[:alert]).to eq('承認または否認を選択してください')
+        end
+
+        it 'ステータスが更新されないこと' do
+          patch bulk_update_monthly_approvals_path, params: pending_status_params
+
+          expect(approval1.reload.status).to eq('pending')
+        end
+      end
+    end
+
+    context 'マネージャー権限がない場合' do
+      before do
+        post login_path, params: { session: { email: regular_user.email, password: "password123" } }
+      end
+
+      it 'ルートパスにリダイレクトすること' do
+        patch bulk_update_monthly_approvals_path, params: { approvals: {} }
+        expect(response).to redirect_to(root_path)
+      end
+    end
   end
 
   describe "POST /users/:user_id/monthly_approvals" do
+    let(:user) do
+      User.create!(name: "申請者", email: "user_#{Time.current.to_i}@example.com", password: "password")
+    end
+    let(:approver) do
+      User.create!(name: "承認者", email: "approver_#{Time.current.to_i}@example.com", password: "password")
+    end
+
+    before do
+      user.attendances.create!(
+        worked_on: target_month,
+        started_at: Time.zone.parse("#{target_month} 09:00"),
+        finished_at: Time.zone.parse("#{target_month} 18:00")
+      )
+      post login_path, params: { session: { email: user.email, password: "password" } }
+    end
+
     context "有効なパラメータの場合" do
       it "新しい月次承認申請が作成されること" do
         expect do
@@ -63,7 +359,6 @@ RSpec.describe "MonthlyApprovals", type: :request do
 
     context "既存の申請がある場合（再承認）" do
       before do
-        # 既存の月次承認を作成（勤怠データは親のbeforeで作成済み）
         MonthlyApproval.create!(
           user:,
           approver:,

--- a/spec/requests/overtime_approvals_spec.rb
+++ b/spec/requests/overtime_approvals_spec.rb
@@ -1,0 +1,311 @@
+require 'rails_helper'
+
+RSpec.describe OvertimeApprovalsController, type: :request do
+  # ヘルパーメソッド: 勤怠データを作成
+  def create_attendance_data(user, target_date = Date.today)
+    user.attendances.create!(
+      worked_on: target_date,
+      started_at: Time.zone.parse("#{target_date} 09:00"),
+      finished_at: Time.zone.parse("#{target_date} 18:00")
+    )
+  end
+
+  let(:subordinate) do
+    User.create!(
+      name: "部下ユーザー",
+      email: "subordinate_#{Time.current.to_i}@example.com",
+      password: "password123",
+      department: "開発部"
+    )
+  end
+
+  let(:manager) do
+    User.create!(
+      name: "マネージャー",
+      email: "manager_#{Time.current.to_i}@example.com",
+      password: "password123",
+      department: "開発部"
+    ).tap do |user|
+      subordinate.update!(manager_id: user.id)
+    end
+  end
+
+  let(:regular_user) do
+    User.create!(
+      name: "一般ユーザー",
+      email: "regular_#{Time.current.to_i}@example.com",
+      password: "password123",
+      department: "開発部"
+    )
+  end
+
+  describe 'GET #index' do
+    context 'マネージャーとしてログインしている場合' do
+      before do
+        post login_path, params: { session: { email: manager.email, password: "password123" } }
+      end
+
+      it 'HTTPステータス200を返すこと' do
+        get overtime_approvals_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'indexテンプレートを表示すること' do
+        get overtime_approvals_path, xhr: true
+        expect(response.body).to include('残業申請の承認')
+      end
+
+      it '自分が承認者となっている申請中の残業申請を取得すること' do
+        # テストデータ作成
+        user1 = User.create!(name: "申請者1", email: "user1_#{Time.current.to_i}@example.com", password: "password123")
+        user2 = User.create!(name: "申請者2", email: "user2_#{Time.current.to_i}@example.com", password: "password123")
+        user_for_approved = User.create!(name: "承認済申請者", email: "approved_#{Time.current.to_i}@example.com",
+                                         password: "password123")
+
+        # 勤怠データを作成
+        create_attendance_data(user1)
+        create_attendance_data(user2)
+        create_attendance_data(user_for_approved)
+
+        OvertimeRequest.create!(
+          user: user1,
+          approver: manager,
+          worked_on: Date.today,
+          estimated_end_time: Time.zone.parse("#{Date.today} 22:00"),
+          business_content: "システム開発",
+          status: :pending
+        )
+
+        OvertimeRequest.create!(
+          user: user2,
+          approver: manager,
+          worked_on: Date.today,
+          estimated_end_time: Time.zone.parse("#{Date.today} 21:00"),
+          business_content: "緊急対応",
+          status: :pending
+        )
+
+        OvertimeRequest.create!(
+          user: user_for_approved,
+          approver: manager,
+          worked_on: Date.today,
+          estimated_end_time: Time.zone.parse("#{Date.today} 20:00"),
+          business_content: "定例作業",
+          status: :approved
+        )
+
+        get overtime_approvals_path, xhr: true
+
+        # pendingの2件のみが表示されているか確認
+        expect(OvertimeRequest.pending.where(approver: manager).count).to eq(2)
+        expect(response.body).to include('申請者1')
+        expect(response.body).to include('申請者2')
+        expect(response.body).not_to include('承認済申請者')
+      end
+
+      it '他のマネージャー宛の残業申請は含まれないこと' do
+        other_manager = User.create!(name: "他マネージャー", email: "other_mgr_#{Time.current.to_i}@example.com",
+                                     password: "password123")
+        user3 = User.create!(name: "申請者3", email: "user3_#{Time.current.to_i}@example.com", password: "password123")
+
+        create_attendance_data(user3)
+
+        OvertimeRequest.create!(
+          user: user3,
+          approver: other_manager,
+          worked_on: Date.today,
+          estimated_end_time: Time.zone.parse("#{Date.today} 22:00"),
+          business_content: "開発作業",
+          status: :pending
+        )
+
+        get overtime_approvals_path, xhr: true
+
+        expect(OvertimeRequest.pending.where(approver: manager).count).to eq(0)
+        expect(response.body).not_to include('申請者3')
+      end
+    end
+
+    context 'マネージャー権限がない場合' do
+      before do
+        post login_path, params: { session: { email: regular_user.email, password: "password123" } }
+      end
+
+      it 'ルートパスにリダイレクトすること' do
+        get overtime_approvals_path
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'アラートメッセージを表示すること' do
+        get overtime_approvals_path
+        expect(flash[:alert]).to eq('管理者権限が必要です')
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it 'ログインページにリダイレクトすること' do
+        get overtime_approvals_path
+        expect(response).to redirect_to(login_path)
+      end
+    end
+  end
+
+  describe 'PATCH #bulk_update' do
+    context 'マネージャーとしてログインしている場合' do
+      before do
+        post login_path, params: { session: { email: manager.email, password: "password123" } }
+      end
+
+      let!(:user1) do
+        User.create!(name: "申請者1", email: "ap1_#{Time.current.to_i}@example.com", password: "password123")
+      end
+      let!(:user2) do
+        User.create!(name: "申請者2", email: "ap2_#{Time.current.to_i}@example.com", password: "password123")
+      end
+      let!(:user3) do
+        User.create!(name: "申請者3", email: "ap3_#{Time.current.to_i}@example.com", password: "password123")
+      end
+
+      let!(:attendance1) { create_attendance_data(user1) }
+      let!(:attendance2) { create_attendance_data(user2) }
+      let!(:attendance3) { create_attendance_data(user3) }
+
+      let!(:request1) do
+        OvertimeRequest.create!(
+          user: user1,
+          approver: manager,
+          worked_on: Date.today,
+          estimated_end_time: Time.zone.parse("#{Date.today} 22:00"),
+          business_content: "システム開発",
+          status: :pending
+        )
+      end
+
+      let!(:request2) do
+        OvertimeRequest.create!(
+          user: user2,
+          approver: manager,
+          worked_on: Date.today,
+          estimated_end_time: Time.zone.parse("#{Date.today} 21:00"),
+          business_content: "緊急対応",
+          status: :pending
+        )
+      end
+
+      let!(:request3) do
+        OvertimeRequest.create!(
+          user: user3,
+          approver: manager,
+          worked_on: Date.today,
+          estimated_end_time: Time.zone.parse("#{Date.today} 20:00"),
+          business_content: "定例作業",
+          status: :pending
+        )
+      end
+
+      context '有効なパラメータの場合' do
+        let(:valid_params) do
+          {
+            requests: {
+              request1.id.to_s => { selected: '1', status: 'approved' },
+              request2.id.to_s => { selected: '1', status: 'rejected' },
+              request3.id.to_s => { selected: '0', status: 'pending' }
+            }
+          }
+        end
+
+        it 'チェックされた残業申請のステータスを更新すること' do
+          patch bulk_update_overtime_approvals_path, params: valid_params
+
+          expect(request1.reload.status).to eq('approved')
+          expect(request2.reload.status).to eq('rejected')
+          expect(request3.reload.status).to eq('pending') # チェックなし
+        end
+
+        it 'ユーザー詳細ページにリダイレクトして成功メッセージを表示すること' do
+          patch bulk_update_overtime_approvals_path, params: valid_params
+
+          expect(response).to redirect_to(user_path(manager))
+          expect(flash[:success]).to eq('承認処理が完了しました')
+        end
+
+        it '自分が承認者の申請のみ更新すること' do
+          other_manager = User.create!(name: "他マネージャー", email: "othmgr_#{Time.current.to_i}@example.com",
+                                       password: "password123")
+          user4 = User.create!(name: "申請者4", email: "ap4_#{Time.current.to_i}@example.com", password: "password123")
+          create_attendance_data(user4)
+
+          other_request = OvertimeRequest.create!(
+            user: user4,
+            approver: other_manager,
+            worked_on: Date.today,
+            estimated_end_time: Time.zone.parse("#{Date.today} 22:00"),
+            business_content: "開発作業",
+            status: :pending
+          )
+
+          params = {
+            requests: {
+              other_request.id.to_s => { selected: '1', status: 'approved' }
+            }
+          }
+
+          patch(bulk_update_overtime_approvals_path, params:)
+
+          expect(other_request.reload.status).to eq('pending') # 変更されない
+        end
+      end
+
+      context 'チェックされた項目がない場合' do
+        let(:no_selection_params) do
+          {
+            requests: {
+              request1.id.to_s => { selected: '0', status: 'approved' }
+            }
+          }
+        end
+
+        it 'アラートメッセージを表示してリダイレクトすること' do
+          patch bulk_update_overtime_approvals_path, params: no_selection_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(flash.now[:alert]).to eq('承認する項目を選択してください')
+        end
+      end
+
+      context 'チェックされているが承認/否認が選択されていない場合' do
+        let(:pending_status_params) do
+          {
+            requests: {
+              request1.id.to_s => { selected: '1', status: 'pending' }
+            }
+          }
+        end
+
+        it 'アラートメッセージを表示してリダイレクトすること' do
+          patch bulk_update_overtime_approvals_path, params: pending_status_params
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(flash.now[:alert]).to eq('承認または否認を選択してください')
+        end
+
+        it 'ステータスが更新されないこと' do
+          patch bulk_update_overtime_approvals_path, params: pending_status_params
+
+          expect(request1.reload.status).to eq('pending')
+        end
+      end
+    end
+
+    context 'マネージャー権限がない場合' do
+      before do
+        post login_path, params: { session: { email: regular_user.email, password: "password123" } }
+      end
+
+      it 'ルートパスにリダイレクトすること' do
+        patch bulk_update_overtime_approvals_path, params: { requests: {} }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
残業承認モーダル機能を実装し、月次承認モーダルのUIも統一しました。

## 実装内容

### 1. 残業承認機能（TDD）
- **テスト**: `spec/requests/overtime_approvals_spec.rb`（14例）
  - GET #index: 7例
  - PATCH #bulk_update: 7例
- **コントローラー**: `OvertimeApprovalsController`
  - マネージャー権限チェック
  - 一括承認/否認処理
  - トランザクション管理
- **ビュー**: `app/views/overtime_approvals/index.html.erb`
  - 申請者グループ化UI
  - 退社時刻、終了予定時間、残業時間、業務内容の表示
- **ルーティング**: `bulk_updatable` concern利用

### 2. 月次承認UI統一
- **申請者グループ化**: `group_by(&:user)` で統一UI
- **N+1対策**: `.includes(:user)` をコントローラーの4箇所に追加
- **テスト追加**: GET #index, PATCH #bulk_update（計21例）
- **タイトル変更**: "所属長承認申請の承認"に統一

### 3. ビュー修正
- 残業承認リンクをダミーから実際のパスに変更

## テスト結果
- **残業承認**: 14 examples, 0 failures ✅
- **月次承認**: 21 examples, 0 failures ✅
- **Rubocop**: no offenses detected ✅

## UI/UX
- 全承認モーダルで申請者名をグループ化表示
- 承認/否認の選択とチェックボックスで一括処理
- 勤怠確認リンクで新規タブで詳細確認可能

## 関連
- Feature/29の残業承認パターンを踏襲
- 既存の月次承認・勤怠変更承認とUI統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)